### PR TITLE
Model/issue 28 scet

### DIFF
--- a/SBN_NUCSPEC_1A00_0000.xml
+++ b/SBN_NUCSPEC_1A00_0000.xml
@@ -108,7 +108,7 @@
     <local_identifier>nucspec.et_start</local_identifier>
     <nillable_flag>false</nillable_flag>
     <submitter_name>Small Bodies Node</submitter_name>
-    <definition>Ephemeris time, as defined by the referenced field, for the first science data record for a block of records with the same state.</definition>
+    <definition>The earliest ephemeris time, as defined by the referenced field, for which this state is applicable.</definition>
     <DD_Value_Domain>
       <enumeration_flag>false</enumeration_flag>
       <value_data_type>ASCII_Real</value_data_type>
@@ -121,7 +121,7 @@
     <local_identifier>nucspec.et_stop</local_identifier>
     <nillable_flag>false</nillable_flag>
     <submitter_name>Small Bodies Node</submitter_name>
-    <definition>Ephemeris time, as defined by the referenced field, for the last science data record for a block of records with the same state.</definition>
+    <definition>The latest ephemeris time, as defined by the referenced field, for which this state is applicable.</definition>
     <DD_Value_Domain>
       <enumeration_flag>false</enumeration_flag>
       <value_data_type>ASCII_Real</value_data_type>
@@ -134,7 +134,7 @@
     <local_identifier>nucspec.sclk_start_time</local_identifier>
     <nillable_flag>false</nillable_flag>
     <submitter_name>Small Bodies Node</submitter_name>
-    <definition>Spacecraft clock time in ticks since spacecraft clock start for the first science data record for a block of records with the same state.</definition>
+    <definition>The earliest spacecraft clock time, in ticks since spacecraft clock start, for which this state is applicable.</definition>
     <DD_Value_Domain>
       <enumeration_flag>false</enumeration_flag>
       <value_data_type>ASCII_Integer</value_data_type>
@@ -148,7 +148,7 @@
     <local_identifier>nucspec.sclk_stop_time</local_identifier>
     <nillable_flag>false</nillable_flag>
     <submitter_name>Small Bodies Node</submitter_name>
-    <definition>Spacecraft clock time in ticks since spacecraft clock start for the last science data record for a block of records with the same state.</definition>
+    <definition>The latest spacecraft clock time, in ticks since spacecraft clock start, for which this state is applicable.</definition>
     <DD_Value_Domain>
       <enumeration_flag>false</enumeration_flag>
       <value_data_type>ASCII_Integer</value_data_type>
@@ -162,7 +162,7 @@
     <local_identifier>nucspec.utc_start_time</local_identifier>
     <nillable_flag>false</nillable_flag>
     <submitter_name>Small Bodies Node</submitter_name>
-    <definition>Universal Coordinated Time for the first science data record for a block of records with the same state.</definition>
+    <definition>The earliest Universal Coordinated Time for which this state is applicable.</definition>
     <DD_Value_Domain>
       <enumeration_flag>false</enumeration_flag>
       <value_data_type>ASCII_Date_Time_YMD_UTC</value_data_type>
@@ -175,7 +175,7 @@
     <local_identifier>nucspec.utc_stop_time</local_identifier>
     <nillable_flag>false</nillable_flag>
     <submitter_name>Small Bodies Node</submitter_name>
-    <definition>Universal Coordinated Time for the last science data record for a block of records with the same state.</definition>
+    <definition>The earliest Universal Coordinated Time for which this state is applicable.</definition>
     <DD_Value_Domain>
       <enumeration_flag>false</enumeration_flag>
       <value_data_type>ASCII_Date_Time_YMD_UTC</value_data_type>
@@ -492,7 +492,7 @@ The record numbers are one-based and inclusive.</definition>
     <version_id>1.0</version_id>
     <local_identifier>State_Time_ET</local_identifier>
     <submitter_name>Small Bodies Node</submitter_name>
-    <definition>Ephemeris time, as defined by the referenced field, for the first and last science data records for a block of records with the same state.</definition>
+    <definition>Ephemeris time, as defined by the referenced field, for the first and last science data records for a temporally contiguous block of records with the same state. These records need not be contiguous within the file, but there must be no records with a different state between the start and stop time.</definition>
     <DD_Association>
       <identifier_reference>nucspec.et_start</identifier_reference>
       <reference_type>attribute_of</reference_type>
@@ -511,7 +511,7 @@ The record numbers are one-based and inclusive.</definition>
     <version_id>1.0</version_id>
     <local_identifier>State_Time_SCLK</local_identifier>
     <submitter_name>Small Bodies Node</submitter_name>
-    <definition>Spacecraft clock time in ticks since spacecraft clock start for the first and last science data records for a block of records with the same state.</definition>
+    <definition>Spacecraft clock time in ticks since spacecraft clock start for the first and last science data records for a temporally contiguous block of records with the same state. These records need not be contiguous within the file, but there must be no records with a different state between the start and stop time.</definition>
     <DD_Association>
       <identifier_reference>nucspec.sclk_start_time</identifier_reference>
       <reference_type>attribute_of</reference_type>
@@ -530,7 +530,7 @@ The record numbers are one-based and inclusive.</definition>
     <version_id>1.0</version_id>
     <local_identifier>State_Time_UTC</local_identifier>
     <submitter_name>Small Bodies Node</submitter_name>
-    <definition>Universal Coordinated Time for the first and last science data records for a block of records with the same state.</definition>
+    <definition>Universal Coordinated Time for the first and last science data records for a temporally contiguous block of records with the same state. These records need not be contiguous within the file, but there must be no records with a different state between the start and stop time.</definition>
     <DD_Association>
       <identifier_reference>nucspec.utc_start_time</identifier_reference>
       <reference_type>attribute_of</reference_type>

--- a/SBN_NUCSPEC_1A00_0000.xml
+++ b/SBN_NUCSPEC_1A00_0000.xml
@@ -638,4 +638,18 @@ The record numbers are one-based and inclusive.</definition>
     </DD_Rule_Statement>
   </DD_Rule>
 
+
+  <DD_Rule>
+    <local_identifier>state_time_field_exists</local_identifier>
+    <rule_context>nucspec:State_Time</rule_context>
+    <rule_assign>name="local_id" value="../pds:Local_Internal_Reference/pds:local_identifier_reference"</rule_assign>
+    <rule_assign>name="field_name" value="nucspec:state_time_field_name"</rule_assign>
+    <DD_Rule_Statement>
+      <rule_type>Assert</rule_type>
+      <rule_test>//(pds:Table_Character | pds:Table_Delimited | pds:Table_Binary)[pds:local_identifier = $local_id]//(pds:Field_Character | pds:Field_Delimited | pds:Field_Binary)[pds:name=$field_name]</rule_test>
+      <rule_message>In the nucspec:State_Time class, state_time_field_name (&lt;sch:value-of select='$field_name'/&gt;) must reference a field in the referenced data table (&lt;sch:value-of select='$local_id'/&gt;).</rule_message>
+      <rule_description>In the nucspec:State_Time class, state_time_field_name must reference a field in the referenced data table.</rule_description>
+    </DD_Rule_Statement>
+  </DD_Rule>  
+
 </Ingest_LDD>

--- a/SBN_NUCSPEC_1A00_0000.xml
+++ b/SBN_NUCSPEC_1A00_0000.xml
@@ -90,12 +90,25 @@
     </DD_Value_Domain>
   </DD_Attribute>
   <DD_Attribute>
-    <name>scet_start</name>
+    <name>state_time_field_name</name>
     <version_id>1.0</version_id>
-    <local_identifier>nucspec.scet_start</local_identifier>
+    <local_identifier>nucspec.state_time_field_name</local_identifier>
     <nillable_flag>false</nillable_flag>
     <submitter_name>Small Bodies Node</submitter_name>
-    <definition>Spacecraft event time in seconds past J2000 for the first science data record for a block of records with the same state.</definition>
+    <definition>The name of the field in the referenced data table that contains the time.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>UTF8_String</value_data_type>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+  <DD_Attribute>
+    <name>et_start</name>
+    <version_id>1.0</version_id>
+    <local_identifier>nucspec.et_start</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Small Bodies Node</submitter_name>
+    <definition>Ephemeris time, as defined by the referenced field, for the first science data record for a block of records with the same state.</definition>
     <DD_Value_Domain>
       <enumeration_flag>false</enumeration_flag>
       <value_data_type>ASCII_Real</value_data_type>
@@ -103,12 +116,12 @@
     </DD_Value_Domain>
   </DD_Attribute>
   <DD_Attribute>
-    <name>scet_stop</name>
+    <name>et_stop</name>
     <version_id>1.0</version_id>
-    <local_identifier>nucspec.scet_stop</local_identifier>
+    <local_identifier>nucspec.et_stop</local_identifier>
     <nillable_flag>false</nillable_flag>
     <submitter_name>Small Bodies Node</submitter_name>
-    <definition>Spacecraft event time in seconds past J2000 for the last science data record for a block of records with the same state.</definition>
+    <definition>Ephemeris time, as defined by the referenced field, for the last science data record for a block of records with the same state.</definition>
     <DD_Value_Domain>
       <enumeration_flag>false</enumeration_flag>
       <value_data_type>ASCII_Real</value_data_type>
@@ -377,10 +390,17 @@
     <version_id>1.0</version_id>
     <local_identifier>State_Time</local_identifier>
     <submitter_name>Small Bodies Node</submitter_name>
-    <definition>The time during which this state was applicable.</definition>
+    <definition>The time during which this state was applicable. The state table entry is applicable to records in the referenced data table if the time of the data record, as given by state_time_field_name, is between the start time and stop time given in State_Time.</definition>
+    <DD_Association>
+      <identifier_reference>nucspec.state_time_field_name</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>1</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+
     <DD_Association>
       <identifier_reference>XSChoice#</identifier_reference>
-      <identifier_reference>State_Time_SCET</identifier_reference>
+      <identifier_reference>State_Time_ET</identifier_reference>
       <identifier_reference>State_Time_SCLK</identifier_reference>
       <identifier_reference>State_Time_UTC</identifier_reference>
       <reference_type>component_of</reference_type>
@@ -468,19 +488,19 @@ The record numbers are one-based and inclusive.</definition>
     </DD_Association>
   </DD_Class>
   <DD_Class>
-    <name>State_Time_SCET</name>
+    <name>State_Time_ET</name>
     <version_id>1.0</version_id>
-    <local_identifier>State_Time_SCET</local_identifier>
+    <local_identifier>State_Time_ET</local_identifier>
     <submitter_name>Small Bodies Node</submitter_name>
-    <definition>Spacecraft event time in seconds past J2000 for the first and last science data records for a block of records with the same state.</definition>
+    <definition>Ephemeris time, as defined by the referenced field, for the first and last science data records for a block of records with the same state.</definition>
     <DD_Association>
-      <identifier_reference>nucspec.scet_start</identifier_reference>
+      <identifier_reference>nucspec.et_start</identifier_reference>
       <reference_type>attribute_of</reference_type>
       <minimum_occurrences>1</minimum_occurrences>
       <maximum_occurrences>1</maximum_occurrences>
     </DD_Association>
     <DD_Association>
-      <identifier_reference>nucspec.scet_stop</identifier_reference>
+      <identifier_reference>nucspec.et_stop</identifier_reference>
       <reference_type>attribute_of</reference_type>
       <minimum_occurrences>1</minimum_occurrences>
       <maximum_occurrences>1</maximum_occurrences>
@@ -604,4 +624,5 @@ The record numbers are one-based and inclusive.</definition>
       <rule_description>In the nucspec:First_Last class, the index of the last record must be less than or equal to the record count of the referenced table.</rule_description>
     </DD_Rule_Statement>
   </DD_Rule>
+
 </Ingest_LDD>

--- a/SBN_NUCSPEC_1A00_0000.xml
+++ b/SBN_NUCSPEC_1A00_0000.xml
@@ -356,6 +356,12 @@
       <maximum_occurrences>1</maximum_occurrences>
     </DD_Association>
     <DD_Association>
+      <identifier_reference>pds.Local_Internal_Reference</identifier_reference>
+      <reference_type>component_of</reference_type>
+      <minimum_occurrences>1</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
       <identifier_reference>XSChoice#</identifier_reference>
       <identifier_reference>Applicable_Records</identifier_reference>
       <identifier_reference>State_Time</identifier_reference>
@@ -370,12 +376,6 @@
     <local_identifier>Applicable_Records</local_identifier>
     <submitter_name>Small Bodies Node</submitter_name>
     <definition>The records to which this state applies.</definition>
-    <DD_Association>
-      <identifier_reference>pds.Local_Internal_Reference</identifier_reference>
-      <reference_type>component_of</reference_type>
-      <minimum_occurrences>1</minimum_occurrences>
-      <maximum_occurrences>1</maximum_occurrences>
-    </DD_Association>
     <DD_Association>
       <identifier_reference>XSChoice#</identifier_reference>
       <identifier_reference>First_Last</identifier_reference>
@@ -577,7 +577,7 @@ The record numbers are one-based and inclusive.</definition>
 
   <DD_Rule>
     <local_identifier>applicable_records_local_reference_type</local_identifier>
-    <rule_context>nucspec:Applicable_Records/pds:Local_Internal_Reference</rule_context>
+    <rule_context>nucspec:State_Table_Entry/pds:Local_Internal_Reference</rule_context>
     <DD_Rule_Statement>
       <rule_type>Assert</rule_type>
       <rule_test>pds:local_reference_type = ('state_table_to_data_table')</rule_test>
@@ -588,7 +588,7 @@ The record numbers are one-based and inclusive.</definition>
   <DD_Rule>
     <local_identifier>applicable_records_require_record_count</local_identifier>
     <rule_context>nucspec:Applicable_Records</rule_context>
-    <rule_assign>name="local_id" value="pds:Local_Internal_Reference/pds:local_identifier_reference"</rule_assign>
+    <rule_assign>name="local_id" value="../pds:Local_Internal_Reference/pds:local_identifier_reference"</rule_assign>
     <DD_Rule_Statement>
       <rule_type>Assert</rule_type>
       <rule_test>//*[pds:local_identifier=$local_id]/pds:records</rule_test>
@@ -598,9 +598,22 @@ The record numbers are one-based and inclusive.</definition>
   </DD_Rule>
 
   <DD_Rule>
+    <local_identifier>state_table_entry_table_exists</local_identifier>
+    <rule_context>nucspec:State_Table_Entry</rule_context>
+    <rule_assign>name="local_id" value="pds:Local_Internal_Reference/pds:local_identifier_reference"</rule_assign>
+    <DD_Rule_Statement>
+      <rule_type>Assert</rule_type>
+      <rule_test>//(pds:Table_Character | pds:Table_Delimited | pds:Table_Binary)[pds:local_identifier = $local_id]</rule_test>
+      <rule_message>In the nucspec:State_Table_Entry class, the local_identifier_reference (&lt;sch:value-of select='$local_id'/&gt;) must reference a table.</rule_message>
+      <rule_description>In the nucspec:State_Table_Entry class, the local_identifier_reference must reference a table.</rule_description>
+    </DD_Rule_Statement>
+  </DD_Rule>
+
+
+  <DD_Rule>
     <local_identifier>last_bounds_check</local_identifier>
     <rule_context>nucspec:First_Last</rule_context>
-    <rule_assign>name="local_id" value="../pds:Local_Internal_Reference/pds:local_identifier_reference"</rule_assign>
+    <rule_assign>name="local_id" value="../../pds:Local_Internal_Reference/pds:local_identifier_reference"</rule_assign>
     <rule_assign>name="record_count" value="number(//*[pds:local_identifier=$local_id]/pds:records)"</rule_assign>
     <rule_assign>name="last_record" value="number(nucspec:last_record)"</rule_assign>
     <DD_Rule_Statement>
@@ -614,7 +627,7 @@ The record numbers are one-based and inclusive.</definition>
   <DD_Rule>
     <local_identifier>first_count_bounds_check</local_identifier>
     <rule_context>nucspec:First_Count</rule_context>
-    <rule_assign>name="local_id" value="../pds:Local_Internal_Reference/pds:local_identifier_reference"</rule_assign>
+    <rule_assign>name="local_id" value="../../pds:Local_Internal_Reference/pds:local_identifier_reference"</rule_assign>
     <rule_assign>name="record_count" value="number(//*[pds:local_identifier=$local_id]/pds:records)"</rule_assign>
     <rule_assign>name="last_record" value="number(nucspec:first_record) + number(nucspec:record_count) - 1"</rule_assign>
     <DD_Rule_Statement>

--- a/tests/fail/applicable_records_local_reference_type.xml
+++ b/tests/fail/applicable_records_local_reference_type.xml
@@ -68,11 +68,11 @@
             </Internal_Reference>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>applicable_recordz_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>applicable_recordz_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Count>
                   <nucspec:first_record>1</nucspec:first_record>
                   <nucspec:record_count>1</nucspec:record_count>
@@ -81,11 +81,11 @@
             </nucspec:State_Table_Entry>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>2</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>applicable_recordz_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>applicable_recordz_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Count>
                   <nucspec:first_record>2</nucspec:first_record>
                   <nucspec:record_count>8000</nucspec:record_count>

--- a/tests/fail/applicable_records_require_record_count.xml
+++ b/tests/fail/applicable_records_require_record_count.xml
@@ -68,11 +68,11 @@
             </Internal_Reference>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>tabl</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>tabl</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Count>
                   <nucspec:first_record>1</nucspec:first_record>
                   <nucspec:record_count>1</nucspec:record_count>
@@ -81,11 +81,11 @@
             </nucspec:State_Table_Entry>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>2</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Count>
                   <nucspec:first_record>2</nucspec:first_record>
                   <nucspec:record_count>8000</nucspec:record_count>

--- a/tests/fail/cal_ref_doc.xml
+++ b/tests/fail/cal_ref_doc.xml
@@ -74,11 +74,11 @@
             </Internal_Reference>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Count>
                   <nucspec:first_record>1</nucspec:first_record>
                   <nucspec:record_count>1</nucspec:record_count>
@@ -87,11 +87,11 @@
             </nucspec:State_Table_Entry>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>2</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Count>
                   <nucspec:first_record>2</nucspec:first_record>
                   <nucspec:record_count>8000</nucspec:record_count>

--- a/tests/fail/fail_first_last_ordering.xml
+++ b/tests/fail/fail_first_last_ordering.xml
@@ -68,11 +68,11 @@
             </Internal_Reference>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Last>
                   <nucspec:first_record>2</nucspec:first_record>
                   <nucspec:last_record>1</nucspec:last_record>
@@ -81,11 +81,11 @@
             </nucspec:State_Table_Entry>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>2</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Last>
                   <nucspec:first_record>2</nucspec:first_record>
                   <nucspec:last_record>3</nucspec:last_record>

--- a/tests/fail/first_count_bounds_check.xml
+++ b/tests/fail/first_count_bounds_check.xml
@@ -68,11 +68,11 @@
             </Internal_Reference>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Count>
                   <nucspec:first_record>1</nucspec:first_record>
                   <nucspec:record_count>1</nucspec:record_count>
@@ -81,11 +81,11 @@
             </nucspec:State_Table_Entry>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>2</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Count>
                   <nucspec:first_record>2</nucspec:first_record>
                   <nucspec:record_count>9000</nucspec:record_count>

--- a/tests/fail/last_bounds_check.xml
+++ b/tests/fail/last_bounds_check.xml
@@ -68,11 +68,11 @@
             </Internal_Reference>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Last>
                   <nucspec:first_record>1</nucspec:first_record>
                   <nucspec:last_record>1</nucspec:last_record>
@@ -81,11 +81,11 @@
             </nucspec:State_Table_Entry>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>2</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Last>
                   <nucspec:first_record>2</nucspec:first_record>
                   <nucspec:last_record>70000</nucspec:last_record>

--- a/tests/fail/state_table_entry_table_exists.xml
+++ b/tests/fail/state_table_entry_table_exists.xml
@@ -9,7 +9,7 @@
                       http://pds.nasa.gov/pds4/nucspec/v0 https://pds.nasa.gov/pds4/pds/v1/PDS4_nucspec_1000.xsd
                      ">
   <Identification_Area>
-    <logical_identifier>urn:nasa:pds:dawn_grand:data:pass8</logical_identifier>
+    <logical_identifier>urn:nasa:pds:dawn_grand:data:state_table_ref</logical_identifier>
     <version_id>0.0</version_id>
     <title>GRaND BGO 2015-03-16T23:59:03</title>
     <information_model_version>1.10.0.0</information_model_version>
@@ -72,13 +72,25 @@
                   <local_identifier_reference>table</local_identifier_reference>
                   <local_reference_type>state_table_to_data_table</local_reference_type>
               </Local_Internal_Reference>
-              <nucspec:State_Time>
-                <nucspec:state_time_field_name>SCET_UTC</nucspec:state_time_field_name>
-                <nucspec:State_Time_UTC>
-                  <nucspec:utc_start_time>2015-03-16T23:59:03Z</nucspec:utc_start_time>
-                  <nucspec:utc_stop_time>2015-03-17T23:59:03Z</nucspec:utc_stop_time>
-                </nucspec:State_Time_UTC>
-              </nucspec:State_Time>
+              <nucspec:Applicable_Records>
+                <nucspec:First_Last>
+                  <nucspec:first_record>1</nucspec:first_record>
+                  <nucspec:last_record>1</nucspec:last_record>
+                </nucspec:First_Last>
+              </nucspec:Applicable_Records>
+            </nucspec:State_Table_Entry>
+            <nucspec:State_Table_Entry>
+              <nucspec:state_index>2</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>tabl</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
+              <nucspec:Applicable_Records>
+                <nucspec:First_Last>
+                  <nucspec:first_record>2</nucspec:first_record>
+                  <nucspec:last_record>3</nucspec:last_record>
+                </nucspec:First_Last>
+              </nucspec:Applicable_Records>
             </nucspec:State_Table_Entry>
           </nucspec:State_Table>
         </nucspec:Instrument_Settings>

--- a/tests/fail/state_table_ref.xml
+++ b/tests/fail/state_table_ref.xml
@@ -68,11 +68,11 @@
             </Internal_Reference>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Count>
                   <nucspec:first_record>1</nucspec:first_record>
                   <nucspec:record_count>1</nucspec:record_count>
@@ -81,11 +81,11 @@
             </nucspec:State_Table_Entry>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>2</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Count>
                   <nucspec:first_record>2</nucspec:first_record>
                   <nucspec:record_count>8000</nucspec:record_count>

--- a/tests/fail/state_time_field_exists_1.xml
+++ b/tests/fail/state_time_field_exists_1.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1A00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="https://pds.nasa.gov/pds4/nucspec/v1/PDS4_nucspec_1000.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Observational 
+  xmlns="http://pds.nasa.gov/pds4/pds/v1" 
+  xmlns:nucspec="http://pds.nasa.gov/pds4/nucspec/v0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1A00.xsd
+                      http://pds.nasa.gov/pds4/nucspec/v0 https://pds.nasa.gov/pds4/pds/v1/PDS4_nucspec_1000.xsd
+                     ">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:dawn_grand:data:state_time_field_exists_1</logical_identifier>
+    <version_id>0.0</version_id>
+    <title>GRaND BGO 2015-03-16T23:59:03</title>
+    <information_model_version>1.10.0.0</information_model_version>
+    <product_class>Product_Observational</product_class>
+  </Identification_Area>
+  <Observation_Area>
+    <Time_Coordinates>
+      <start_date_time>2015-03-16T23:59:03Z</start_date_time>
+      <stop_date_time>2015-04-23T23:58:03Z</stop_date_time>
+    </Time_Coordinates>
+    <Primary_Result_Summary>
+      <purpose>Science</purpose>
+      <processing_level>Calibrated</processing_level>
+    </Primary_Result_Summary>
+    <Investigation_Area>
+      <name>DAWN</name>
+      <type>Mission</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:mission:dawn</lid_reference>
+        <reference_type>data_to_investigation</reference_type>
+      </Internal_Reference>
+    </Investigation_Area>
+    <Observing_System>
+      <Observing_System_Component>
+        <name>Gamma-Ray and Neutron Detector</name>
+        <type>Instrument</type>
+      </Observing_System_Component>
+    </Observing_System>
+    <Target_Identification>
+      <name>(1) Ceres</name>
+      <type>Dwarf Planet</type>
+    </Target_Identification>
+    <Discipline_Area>
+      <nucspec:NucSpec_Observation_Properties>
+        <nucspec:Energy_Calibration>
+          <nucspec:Polynomial>
+            <nucspec:Polynomial_Term>
+              <nucspec:order>0</nucspec:order>
+              <nucspec:coefficient>23</nucspec:coefficient>
+            </nucspec:Polynomial_Term>
+            <nucspec:Polynomial_Term>
+              <nucspec:order>1</nucspec:order>
+              <nucspec:coefficient>1</nucspec:coefficient>
+            </nucspec:Polynomial_Term>
+            <nucspec:Polynomial_Term>
+              <nucspec:order>2</nucspec:order>
+              <nucspec:coefficient>0.25</nucspec:coefficient>
+            </nucspec:Polynomial_Term>
+          </nucspec:Polynomial>
+        </nucspec:Energy_Calibration>
+        <nucspec:Instrument_Settings>
+          <nucspec:State_Table>
+            <Internal_Reference>
+              <lid_reference>urn:nasa:pds:dawn_grand:data:state_table</lid_reference>
+              <reference_type>nucspec_product_to_state_table</reference_type>
+            </Internal_Reference>
+            <nucspec:State_Table_Entry>
+              <nucspec:state_index>1</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
+              <nucspec:State_Time>
+                <nucspec:state_time_field_name>SCET_UTCC</nucspec:state_time_field_name>
+                <nucspec:State_Time_UTC>
+                  <nucspec:utc_start_time>2015-03-16T23:59:03Z</nucspec:utc_start_time>
+                  <nucspec:utc_stop_time>2015-03-17T23:59:03Z</nucspec:utc_stop_time>
+                </nucspec:State_Time_UTC>
+              </nucspec:State_Time>
+            </nucspec:State_Table_Entry>
+          </nucspec:State_Table>
+        </nucspec:Instrument_Settings>
+      </nucspec:NucSpec_Observation_Properties>
+    </Discipline_Area>
+  </Observation_Area>
+  <File_Area_Observational>
+    <File>
+      <file_name>sample_bgo.tab</file_name>
+      <creation_date_time>2018-09-07T00:00:00</creation_date_time>
+      <records>8023</records>
+    </File>
+    <Table_Character>
+      <local_identifier>table</local_identifier>
+      <offset unit="byte">0</offset>
+      <records>8023</records>
+      <description>This data file contains a time series of corrected and calibrated pulse     
+  height spectra measured by GRaND's bismuth germanate (BGO) scintillator     
+  during Ceres encounter. Each row contains the spacecraft clock (SCLK) ticks 
+  and spacecraft event UTC time (SCET_UTC) corresponding to the end of the    
+  science accumulation interval (accurate to 1s). The ephemeris time for the  
+  midpoint of the science interval is also included. Each row also contains   
+  the corresponding 1024-channel BGO spectrum accumulated. Each spectrum has  
+  been subjected to the following corrections:                                
+                                                                              
+    - Removal of analog-to-digital (ADC) differential nonlinearity artifacts  
+    - Gain and offset correction to put each spectrum on the same pulse height
+                                                                              
+  For each channel, the corresponding mid-point pulse height can be determined
+  by multiplying channel index (0-1023) by 8.9 keV/channel.                   
+                                                                              
+  The processing steps, including criteria for including spectra in the time  
+  series, are described by Yamashita and Prettyman, ''Dawn's Gamma Ray and    
+  Neutron Detector: BGO Data Processing'', which can be found in the DOCUMENT 
+  directory of this archive.                                                  
+                                                                              
+  Each record in this file can be matched to a record in the Ephemerides,     
+  Pointing, and Geometry (EPG) data file using the 9 digit SCLK code. The EPG 
+  file contains additional information needed for analysis and mapping,       
+  including the measurement time, spacecraft pointing and position, the solid 
+  angle of Ceres, instrument state information, and a proxy for galactic      
+  cosmic ray counting rates.                                          </description>
+      <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+      <Record_Character>
+        <fields>3</fields>
+        <groups>1</groups>
+        <record_length unit="byte">6188</record_length>
+        <Field_Character>
+          <name>SCLK</name>
+          <field_number>1</field_number>
+          <field_location unit="byte">1</field_location>
+          <data_type>ASCII_Integer</data_type>
+          <field_length unit="byte">10</field_length>
+          <field_format>%10d</field_format>
+          <description>SCLK ticks at the end of the science accumulation interval (s) Each       
+    science data record has a unique SCLK value, which can be used as an      
+    identifier.</description>
+        </Field_Character>
+        <Field_Character>
+          <name>SCET_UTC</name>
+          <field_number>2</field_number>
+          <field_location unit="byte">11</field_location>
+          <data_type>ASCII_Date_Time_YMD</data_type>
+          <field_length unit="byte">20</field_length>
+          <field_format>%-20s</field_format>
+          <description>UTC S/C event time (SCET) at the midpoint of the science accumulation     
+    interval.</description>
+        </Field_Character>
+        <Field_Character>
+          <name>ET_MID</name>
+          <field_number>3</field_number>
+          <field_location unit="byte">31</field_location>
+          <data_type>ASCII_Real</data_type>
+          <field_length unit="byte">12</field_length>
+          <field_format>%12.1f</field_format>
+          <unit>s</unit>
+          <description>Ephemeris time at the midpoint of the science accumulation interval (s).</description>
+        </Field_Character>
+        <Group_Field_Character>
+          <repetitions>1024</repetitions>
+          <fields>1</fields>
+          <groups>0</groups>
+          <group_location unit="byte">43</group_location>
+          <group_length unit="byte">6144</group_length>
+          <Field_Character>
+            <name>BGOC</name>
+            <field_number>1</field_number>
+            <field_location unit="byte">1</field_location>
+            <data_type>ASCII_Integer</data_type>
+            <field_length unit="byte">6</field_length>
+            <field_format>%6d</field_format>
+            <unit>counts</unit>
+            <description>1024-channel, calibrated BGO spectrum. The pulse height of each channel   
+    I=0,1023 is given by 8.9 x I with units of keV.</description>
+          </Field_Character>
+        </Group_Field_Character>
+      </Record_Character>
+    </Table_Character>
+  </File_Area_Observational>
+</Product_Observational>

--- a/tests/fail/state_time_field_exists_2.xml
+++ b/tests/fail/state_time_field_exists_2.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1A00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="https://pds.nasa.gov/pds4/nucspec/v1/PDS4_nucspec_1000.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Observational 
+  xmlns="http://pds.nasa.gov/pds4/pds/v1" 
+  xmlns:nucspec="http://pds.nasa.gov/pds4/nucspec/v0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1A00.xsd
+                      http://pds.nasa.gov/pds4/nucspec/v0 https://pds.nasa.gov/pds4/pds/v1/PDS4_nucspec_1000.xsd
+                     ">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:dawn_grand:data:state_time_field_exists_2</logical_identifier>
+    <version_id>0.0</version_id>
+    <title>GRaND BGO 2015-03-16T23:59:03</title>
+    <information_model_version>1.10.0.0</information_model_version>
+    <product_class>Product_Observational</product_class>
+  </Identification_Area>
+  <Observation_Area>
+    <Time_Coordinates>
+      <start_date_time>2015-03-16T23:59:03Z</start_date_time>
+      <stop_date_time>2015-04-23T23:58:03Z</stop_date_time>
+    </Time_Coordinates>
+    <Primary_Result_Summary>
+      <purpose>Science</purpose>
+      <processing_level>Calibrated</processing_level>
+    </Primary_Result_Summary>
+    <Investigation_Area>
+      <name>DAWN</name>
+      <type>Mission</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:mission:dawn</lid_reference>
+        <reference_type>data_to_investigation</reference_type>
+      </Internal_Reference>
+    </Investigation_Area>
+    <Observing_System>
+      <Observing_System_Component>
+        <name>Gamma-Ray and Neutron Detector</name>
+        <type>Instrument</type>
+      </Observing_System_Component>
+    </Observing_System>
+    <Target_Identification>
+      <name>(1) Ceres</name>
+      <type>Dwarf Planet</type>
+    </Target_Identification>
+    <Discipline_Area>
+      <nucspec:NucSpec_Observation_Properties>
+        <nucspec:Energy_Calibration>
+          <nucspec:Polynomial>
+            <nucspec:Polynomial_Term>
+              <nucspec:order>0</nucspec:order>
+              <nucspec:coefficient>23</nucspec:coefficient>
+            </nucspec:Polynomial_Term>
+            <nucspec:Polynomial_Term>
+              <nucspec:order>1</nucspec:order>
+              <nucspec:coefficient>1</nucspec:coefficient>
+            </nucspec:Polynomial_Term>
+            <nucspec:Polynomial_Term>
+              <nucspec:order>2</nucspec:order>
+              <nucspec:coefficient>0.25</nucspec:coefficient>
+            </nucspec:Polynomial_Term>
+          </nucspec:Polynomial>
+        </nucspec:Energy_Calibration>
+        <nucspec:Instrument_Settings>
+          <nucspec:State_Table>
+            <Internal_Reference>
+              <lid_reference>urn:nasa:pds:dawn_grand:data:state_table</lid_reference>
+              <reference_type>nucspec_product_to_state_table</reference_type>
+            </Internal_Reference>
+            <nucspec:State_Table_Entry>
+              <nucspec:state_index>1</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>tabl</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
+              <nucspec:State_Time>
+                <nucspec:state_time_field_name>SCET_UTC</nucspec:state_time_field_name>
+                <nucspec:State_Time_UTC>
+                  <nucspec:utc_start_time>2015-03-16T23:59:03Z</nucspec:utc_start_time>
+                  <nucspec:utc_stop_time>2015-03-17T23:59:03Z</nucspec:utc_stop_time>
+                </nucspec:State_Time_UTC>
+              </nucspec:State_Time>
+            </nucspec:State_Table_Entry>
+          </nucspec:State_Table>
+        </nucspec:Instrument_Settings>
+      </nucspec:NucSpec_Observation_Properties>
+    </Discipline_Area>
+  </Observation_Area>
+  <File_Area_Observational>
+    <File>
+      <file_name>sample_bgo.tab</file_name>
+      <creation_date_time>2018-09-07T00:00:00</creation_date_time>
+      <records>8023</records>
+    </File>
+    <Table_Character>
+      <local_identifier>table</local_identifier>
+      <offset unit="byte">0</offset>
+      <records>8023</records>
+      <description>This data file contains a time series of corrected and calibrated pulse     
+  height spectra measured by GRaND's bismuth germanate (BGO) scintillator     
+  during Ceres encounter. Each row contains the spacecraft clock (SCLK) ticks 
+  and spacecraft event UTC time (SCET_UTC) corresponding to the end of the    
+  science accumulation interval (accurate to 1s). The ephemeris time for the  
+  midpoint of the science interval is also included. Each row also contains   
+  the corresponding 1024-channel BGO spectrum accumulated. Each spectrum has  
+  been subjected to the following corrections:                                
+                                                                              
+    - Removal of analog-to-digital (ADC) differential nonlinearity artifacts  
+    - Gain and offset correction to put each spectrum on the same pulse height
+                                                                              
+  For each channel, the corresponding mid-point pulse height can be determined
+  by multiplying channel index (0-1023) by 8.9 keV/channel.                   
+                                                                              
+  The processing steps, including criteria for including spectra in the time  
+  series, are described by Yamashita and Prettyman, ''Dawn's Gamma Ray and    
+  Neutron Detector: BGO Data Processing'', which can be found in the DOCUMENT 
+  directory of this archive.                                                  
+                                                                              
+  Each record in this file can be matched to a record in the Ephemerides,     
+  Pointing, and Geometry (EPG) data file using the 9 digit SCLK code. The EPG 
+  file contains additional information needed for analysis and mapping,       
+  including the measurement time, spacecraft pointing and position, the solid 
+  angle of Ceres, instrument state information, and a proxy for galactic      
+  cosmic ray counting rates.                                          </description>
+      <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+      <Record_Character>
+        <fields>3</fields>
+        <groups>1</groups>
+        <record_length unit="byte">6188</record_length>
+        <Field_Character>
+          <name>SCLK</name>
+          <field_number>1</field_number>
+          <field_location unit="byte">1</field_location>
+          <data_type>ASCII_Integer</data_type>
+          <field_length unit="byte">10</field_length>
+          <field_format>%10d</field_format>
+          <description>SCLK ticks at the end of the science accumulation interval (s) Each       
+    science data record has a unique SCLK value, which can be used as an      
+    identifier.</description>
+        </Field_Character>
+        <Field_Character>
+          <name>SCET_UTC</name>
+          <field_number>2</field_number>
+          <field_location unit="byte">11</field_location>
+          <data_type>ASCII_Date_Time_YMD</data_type>
+          <field_length unit="byte">20</field_length>
+          <field_format>%-20s</field_format>
+          <description>UTC S/C event time (SCET) at the midpoint of the science accumulation     
+    interval.</description>
+        </Field_Character>
+        <Field_Character>
+          <name>ET_MID</name>
+          <field_number>3</field_number>
+          <field_location unit="byte">31</field_location>
+          <data_type>ASCII_Real</data_type>
+          <field_length unit="byte">12</field_length>
+          <field_format>%12.1f</field_format>
+          <unit>s</unit>
+          <description>Ephemeris time at the midpoint of the science accumulation interval (s).</description>
+        </Field_Character>
+        <Group_Field_Character>
+          <repetitions>1024</repetitions>
+          <fields>1</fields>
+          <groups>0</groups>
+          <group_location unit="byte">43</group_location>
+          <group_length unit="byte">6144</group_length>
+          <Field_Character>
+            <name>BGOC</name>
+            <field_number>1</field_number>
+            <field_location unit="byte">1</field_location>
+            <data_type>ASCII_Integer</data_type>
+            <field_length unit="byte">6</field_length>
+            <field_format>%6d</field_format>
+            <unit>counts</unit>
+            <description>1024-channel, calibrated BGO spectrum. The pulse height of each channel   
+    I=0,1023 is given by 8.9 x I with units of keV.</description>
+          </Field_Character>
+        </Group_Field_Character>
+      </Record_Character>
+    </Table_Character>
+  </File_Area_Observational>
+</Product_Observational>

--- a/tests/pass/pass_3.xml
+++ b/tests/pass/pass_3.xml
@@ -68,11 +68,11 @@
             </Internal_Reference>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Count>
                   <nucspec:first_record>1</nucspec:first_record>
                   <nucspec:record_count>1</nucspec:record_count>
@@ -81,11 +81,11 @@
             </nucspec:State_Table_Entry>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>2</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Count>
                   <nucspec:first_record>2</nucspec:first_record>
                   <nucspec:record_count>8000</nucspec:record_count>

--- a/tests/pass/pass_4.xml
+++ b/tests/pass/pass_4.xml
@@ -68,11 +68,11 @@
             </Internal_Reference>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Last>
                   <nucspec:first_record>1</nucspec:first_record>
                   <nucspec:last_record>1</nucspec:last_record>
@@ -81,11 +81,11 @@
             </nucspec:State_Table_Entry>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>2</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Last>
                   <nucspec:first_record>2</nucspec:first_record>
                   <nucspec:last_record>3</nucspec:last_record>

--- a/tests/pass/pass_5.xml
+++ b/tests/pass/pass_5.xml
@@ -74,11 +74,11 @@
             </Internal_Reference>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Count>
                   <nucspec:first_record>1</nucspec:first_record>
                   <nucspec:record_count>1</nucspec:record_count>
@@ -87,11 +87,11 @@
             </nucspec:State_Table_Entry>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>2</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:Applicable_Records>
-                <Local_Internal_Reference>
-                    <local_identifier_reference>table</local_identifier_reference>
-                    <local_reference_type>state_table_to_data_table</local_reference_type>
-                </Local_Internal_Reference>
                 <nucspec:First_Count>
                   <nucspec:first_record>2</nucspec:first_record>
                   <nucspec:record_count>8000</nucspec:record_count>

--- a/tests/pass/pass_6.xml
+++ b/tests/pass/pass_6.xml
@@ -69,10 +69,11 @@
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
               <nucspec:State_Time>
-                <nucspec:State_Time_SCET>
-                  <nucspec:scet_start>479865543</nucspec:scet_start>
-                  <nucspec:scet_stop>479866000</nucspec:scet_stop>
-                </nucspec:State_Time_SCET>
+                <nucspec:state_time_field_name>ET_MID</nucspec:state_time_field_name>
+                <nucspec:State_Time_ET>
+                  <nucspec:et_start>479865543</nucspec:et_start>
+                  <nucspec:et_stop>479866000</nucspec:et_stop>
+                </nucspec:State_Time_ET>
               </nucspec:State_Time>
             </nucspec:State_Table_Entry>
           </nucspec:State_Table>

--- a/tests/pass/pass_6.xml
+++ b/tests/pass/pass_6.xml
@@ -68,6 +68,10 @@
             </Internal_Reference>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:State_Time>
                 <nucspec:state_time_field_name>ET_MID</nucspec:state_time_field_name>
                 <nucspec:State_Time_ET>

--- a/tests/pass/pass_7.xml
+++ b/tests/pass/pass_7.xml
@@ -69,6 +69,7 @@
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
               <nucspec:State_Time>
+                <nucspec:state_time_field_name>SCLK</nucspec:state_time_field_name>
                 <nucspec:State_Time_SCLK>
                   <nucspec:sclk_start_time>479865543</nucspec:sclk_start_time>
                   <nucspec:sclk_stop_time>479866000</nucspec:sclk_stop_time>

--- a/tests/pass/pass_7.xml
+++ b/tests/pass/pass_7.xml
@@ -68,6 +68,10 @@
             </Internal_Reference>
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
+              <Local_Internal_Reference>
+                  <local_identifier_reference>table</local_identifier_reference>
+                  <local_reference_type>state_table_to_data_table</local_reference_type>
+              </Local_Internal_Reference>
               <nucspec:State_Time>
                 <nucspec:state_time_field_name>SCLK</nucspec:state_time_field_name>
                 <nucspec:State_Time_SCLK>

--- a/tests/pass/pass_8.xml
+++ b/tests/pass/pass_8.xml
@@ -69,6 +69,7 @@
             <nucspec:State_Table_Entry>
               <nucspec:state_index>1</nucspec:state_index>
               <nucspec:State_Time>
+                <nucspec:state_time_field_name>SCET_UTC</nucspec:state_time_field_name>
                 <nucspec:State_Time_UTC>
                   <nucspec:utc_start_time>2015-03-16T23:59:03Z</nucspec:utc_start_time>
                   <nucspec:utc_stop_time>2015-03-17T23:59:03Z</nucspec:utc_stop_time>


### PR DESCRIPTION
SCET has been reimplemented to refer to Ephemeris Time instead. This change also required that we have State_Time explicitly refer to the field that was being compared to the start and stop times.

Closes issue #28

New class diagram:

![SBN_NUCSPEC_1A00_0000 xml](https://user-images.githubusercontent.com/25939961/59132556-5fc6b300-892a-11e9-93fc-c585eb875cfb.png)
